### PR TITLE
Fix search exception

### DIFF
--- a/jswingripples/src/main/java/org/incha/core/search/Searcher.java
+++ b/jswingripples/src/main/java/org/incha/core/search/Searcher.java
@@ -109,7 +109,7 @@ public class Searcher {
      */
     public void setClassTreeView(ClassTreeView classTreeView) {
         searchMenu.getSearchButton().setEnabled(true);
-        searchMenu.getClearbutton().setEnabled(true);
+        searchMenu.getClearButton().setEnabled(true);
         this.classTreeView = classTreeView;
     }
 
@@ -173,7 +173,6 @@ public class Searcher {
         if(results.size() > 0){
             refreshMaxMin();
         }
-
 
         // Refresh analysis table
         classTreeView.repaint();

--- a/jswingripples/src/main/java/org/incha/core/search/Searcher.java
+++ b/jswingripples/src/main/java/org/incha/core/search/Searcher.java
@@ -117,7 +117,9 @@ public class Searcher {
      * Sets SearchMenu reference.
      * @param searchMenu Search Menu in UI.
      */
-    public void setSearchMenu(SearchMenu searchMenu) {this.searchMenu = searchMenu; }
+    public void setSearchMenu(SearchMenu searchMenu) {
+        this.searchMenu = searchMenu;
+    }
 
     /**
      * Searches the indexes in the Directory.

--- a/jswingripples/src/main/java/org/incha/core/search/Searcher.java
+++ b/jswingripples/src/main/java/org/incha/core/search/Searcher.java
@@ -152,7 +152,10 @@ public class Searcher {
         }
 
         // Update files with most/least search term occurrences
-        refreshMaxMin();
+        if(results.size() > 0){
+            refreshMaxMin();
+        }
+
 
         // Refresh analysis table
         classTreeView.repaint();

--- a/jswingripples/src/main/java/org/incha/core/search/Searcher.java
+++ b/jswingripples/src/main/java/org/incha/core/search/Searcher.java
@@ -14,6 +14,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.Version;
 import org.incha.ui.classview.ClassTreeView;
+import org.incha.ui.search.SearchMenu;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -66,6 +67,11 @@ public class Searcher {
     private int minFrequency;
 
     /**
+     * Reference to SearchMenu in UI.
+     */
+    private SearchMenu searchMenu;
+
+    /**
      * Returns the current instance.
      * @return the current Indexer instance.
      */
@@ -101,7 +107,17 @@ public class Searcher {
      * Set current class view.
      * @param classTreeView the current class view.
      */
-    public void setClassTreeView(ClassTreeView classTreeView) { this.classTreeView = classTreeView; }
+    public void setClassTreeView(ClassTreeView classTreeView) {
+        searchMenu.getSearchButton().setEnabled(true);
+        searchMenu.getClearbutton().setEnabled(true);
+        this.classTreeView = classTreeView;
+    }
+
+    /**
+     * Sets SearchMenu reference.
+     * @param searchMenu Search Menu in UI.
+     */
+    public void setSearchMenu(SearchMenu searchMenu) {this.searchMenu = searchMenu; }
 
     /**
      * Searches the indexes in the Directory.

--- a/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
+++ b/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
@@ -4,6 +4,7 @@ import org.apache.commons.logging.LogFactory;
 import org.incha.core.JavaProject;
 import org.incha.core.JavaProjectsModel;
 import org.incha.core.StatisticsManager;
+import org.incha.core.search.Searcher;
 import org.incha.ui.search.SearchMenu;
 import org.incha.ui.stats.GraphVisualizationAction;
 import org.incha.ui.stats.ImpactGraphVisualizationAction;
@@ -292,8 +293,9 @@ public class JSwingRipplesApplication extends JFrame {
 //        jRipples.add(saveState);
 //        final JMenuItem loadState = new JMenuItem("Load State");
 //        jRipples.add(loadState);        
-        
-        bar.add(new SearchMenu().getSearchPanel());  //Se agrega el menu de búsqueda
+        SearchMenu searchMenu = new SearchMenu();
+        Searcher.getInstance().setSearchMenu(searchMenu);
+        bar.add(searchMenu.getSearchPanel());  //Se agrega el menu de búsqueda
         
         return bar;
     }

--- a/jswingripples/src/main/java/org/incha/ui/search/SearchMenu.java
+++ b/jswingripples/src/main/java/org/incha/ui/search/SearchMenu.java
@@ -11,11 +11,11 @@ public class SearchMenu {
 	/**
      * Default constructor. Se crea un panel de búsqueda para colocarlo en algún menú.
      */
-	private JButton searchButton;
+    private JButton searchButton;
     private JButton clearButton;
 
     public JButton getSearchButton(){return searchButton;}
-    public JButton getClearbutton() {return clearButton;}
+    public JButton getClearButton() {return clearButton;}
 
 	public SearchMenu() {
 		searchPanel = new JPanel();

--- a/jswingripples/src/main/java/org/incha/ui/search/SearchMenu.java
+++ b/jswingripples/src/main/java/org/incha/ui/search/SearchMenu.java
@@ -11,6 +11,12 @@ public class SearchMenu {
 	/**
      * Default constructor. Se crea un panel de búsqueda para colocarlo en algún menú.
      */
+	protected JButton searchButton;
+    protected JButton clearButton;
+
+    public JButton getSearchButton(){return searchButton;}
+    public JButton getClearbutton() {return clearButton;}
+
 	public SearchMenu() {
 		searchPanel = new JPanel();
 		JTextField searchedWords = new JTextField(15);
@@ -18,8 +24,10 @@ public class SearchMenu {
         searchPanel.setLayout(new FlowLayout());
         searchPanel.add(new JLabel("Search:"));
         searchPanel.add(searchedWords);
-        JButton searchButton = new JButton("Go");
-        JButton clearButton = new JButton("Clear");
+        searchButton = new JButton("Go");
+        clearButton = new JButton("Clear");
+        searchButton.setEnabled(false);
+        clearButton.setEnabled(false);
         searchButton.addActionListener(new StartSearchAction(searchedWords));
         clearButton.addActionListener(new ClearSearchAction(searchedWords));
         searchPanel.add(searchButton);

--- a/jswingripples/src/main/java/org/incha/ui/search/SearchMenu.java
+++ b/jswingripples/src/main/java/org/incha/ui/search/SearchMenu.java
@@ -11,8 +11,8 @@ public class SearchMenu {
 	/**
      * Default constructor. Se crea un panel de búsqueda para colocarlo en algún menú.
      */
-	protected JButton searchButton;
-    protected JButton clearButton;
+	private JButton searchButton;
+    private JButton clearButton;
 
     public JButton getSearchButton(){return searchButton;}
     public JButton getClearbutton() {return clearButton;}


### PR DESCRIPTION
The exception happened because the update of the min/max frequencies of search occurrences was being updated even if no occurrences were found. After this another exception surfaced when performing a search before an analysis was done, this was because the search tried to update a non-existent graph, whcih was set after an analysis. The buttons are now blocked until an analysis first occurs.

Fixes Issue #9