### PR TITLE
Text Editor asks for saving files when is required. Problem with tabs closed with mouse scroll solved.

### DIFF
--- a/jswingripples/src/main/java/org/incha/core/texteditor/FileOpen.java
+++ b/jswingripples/src/main/java/org/incha/core/texteditor/FileOpen.java
@@ -138,22 +138,6 @@ public class FileOpen {
     }
 
     /**
-     * getter.
-     * @return the initial Content in String.
-     */
-    public String getContent() {
-        return content;
-    }
-
-    /**
-     * getter.
-     * @return the extension of the file.
-     */
-    public String getExtension() {
-        return extension;
-    }
-
-    /**
      * set the syntax to the text.
      * @param syntax the variable of the syntax.
      */
@@ -193,15 +177,8 @@ public class FileOpen {
         text.setText(content);
     }
     
-    /**
-     * true if the document was changed, else false
-     * @return
-     */
-    public boolean getChanged(){    	
-    	return changed;    	
-    }
     
-    public void setChange(){
+    private void setChange(){
     	changed = true;
     	// The listener isn't needed anymore
     	text.getDocument().removeDocumentListener(doclistener);

--- a/jswingripples/src/main/java/org/incha/core/texteditor/FileOpen.java
+++ b/jswingripples/src/main/java/org/incha/core/texteditor/FileOpen.java
@@ -98,35 +98,6 @@ public class FileOpen {
     /**
      * Closer to the File Open.
      * @param frame The TextEditor.
-     * @param tab The index of the tab that would be close.
-     */
-    public void close( TextEditor frame , int tab ) {
-    	if(changed){
-    		int confirm = JOptionPane.showConfirmDialog(
-    				frame ,
-    				path + "\nhas been modified, would you like to save the changes?" ,
-    				"Confirm" ,
-    				JOptionPane.YES_NO_CANCEL_OPTION );
-            if(confirm == JOptionPane.OK_OPTION) {
-                try {
-                    save();                    
-                }
-                catch (Exception e){
-
-                }
-            }
-            else if (confirm == JOptionPane.NO_OPTION){
-            	frame.closeSelectedTab();
-            }
-    	}
-    	else {
-    		frame.closeSelectedTab();
-    	}       
-    }
-
-    /**
-     * Closer to the File Open.
-     * @param frame The TextEditor.
      */
     public void close( TextEditor frame ) {
     	if(changed){

--- a/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
+++ b/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
@@ -99,7 +99,7 @@ public class JSwingRipplesApplication extends JFrame {
             });
             menu.add(prefs);
 
-            //start analisics
+            //start analysis
             final JMenuItem startAnalysis = new JMenuItem("Start analysis");
             startAnalysis.addActionListener(new StartAnalysisAction());
             menu.add(startAnalysis);

--- a/jswingripples/src/main/java/org/incha/ui/texteditor/TextEditor.java
+++ b/jswingripples/src/main/java/org/incha/ui/texteditor/TextEditor.java
@@ -18,7 +18,6 @@ public class TextEditor extends JFrame {
 
     private ArrayList<FileOpen> openFiles;
     private static TextEditor instance;
-    private int tab;
     private JTabbedPane jTabbedPane;
 
     private JMenu fileMenu = new JMenu( "File" );
@@ -52,7 +51,7 @@ public class TextEditor extends JFrame {
             @Override
             public void mouseClicked(MouseEvent e) {
                 if (e.getButton() == MouseEvent.BUTTON2){
-                    openFiles.get(jTabbedPane.indexAtLocation(e.getX(),e.getY())).close(instance,jTabbedPane.indexAtLocation(e.getX(),e.getY()));
+                    openFiles.get(jTabbedPane.indexAtLocation(e.getX(),e.getY())).close(instance);
                 }
                 super.mouseClicked(e);
             }
@@ -105,15 +104,6 @@ public class TextEditor extends JFrame {
     }
 
     /**
-     * Close a Tab in the JTabbedPane.
-     * @param tab the index of the Tab that be close.
-     */
-    public void closeTab(int tab){    	
-        jTabbedPane.remove(tab);
-        openFiles.remove(tab);
-    }
-
-    /**
      * Close the Current tab in the View.
      */
     public void closeSelectedTab(){
@@ -149,7 +139,7 @@ public class TextEditor extends JFrame {
                 	int tabCount = openFiles.size();
                 	for (int tabIndex=tabCount - 1; tabIndex>=0; tabIndex--){
                         try{
-                            openFiles.get((tabIndex)).close(instance, tabIndex);
+                            openFiles.get((tabIndex)).close(instance);
                         }
                         catch (Exception exception)
                         {

--- a/jswingripples/src/main/java/org/incha/ui/texteditor/TextEditor.java
+++ b/jswingripples/src/main/java/org/incha/ui/texteditor/TextEditor.java
@@ -108,20 +108,23 @@ public class TextEditor extends JFrame {
      * Close a Tab in the JTabbedPane.
      * @param tab the index of the Tab that be close.
      */
-    public void closeTab(int tab){
+    public void closeTab(int tab){    	
         jTabbedPane.remove(tab);
+        openFiles.remove(tab);
     }
 
     /**
      * Close the Current tab in the View.
      */
     public void closeSelectedTab(){
-        jTabbedPane.remove(jTabbedPane.getSelectedIndex());
+    	int closedTab = jTabbedPane.getSelectedIndex();
+        jTabbedPane.remove(closedTab);
+        openFiles.remove(closedTab);
     }
 
     /**
      * Constructor.
-     * @param jSwingRipplesApplication in case to be necesary.
+     * @param jSwingRipplesApplication in case to be necessary.
      */
     public TextEditor (JSwingRipplesApplication jSwingRipplesApplication){
         super( "Text Editor" );
@@ -136,30 +139,52 @@ public class TextEditor extends JFrame {
         setVisible( true );
 
         //close option to don't close the program.
-        setDefaultCloseOperation( JFrame.DISPOSE_ON_CLOSE );
+        setDefaultCloseOperation( JFrame.DO_NOTHING_ON_CLOSE );
         //save files when close the program.
         this.addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
                 if(jTabbedPane.getTabCount()>0)
                 {
-                    int confirm = JOptionPane.showConfirmDialog(instance,"Would you like to save the changes?","Confirm",JOptionPane.YES_NO_OPTION);
-
-                    if(confirm ==0){
-                        for (int i=0;i<jTabbedPane.getTabCount();i++){
-                            try{
-                                openFiles.get((i)).save();
-                            }
-                            catch (Exception exception)
-                            {
-                                exception.printStackTrace();
-                            }
+                	int tabCount = openFiles.size();
+                	for (int tabIndex=tabCount - 1; tabIndex>=0; tabIndex--){
+                        try{
+                            openFiles.get((tabIndex)).close(instance, tabIndex);
                         }
-                        JOptionPane.showMessageDialog(instance,"Saved");
-                    }
+                        catch (Exception exception)
+                        {
+                            exception.printStackTrace();
+                        }
+                    }                                                                    
+                    instance=null;
+                    setVisible(false);
+                    dispose();
+                	
+//                    int confirm = JOptionPane.showConfirmDialog(instance,"Would you like to save the changes?","Confirm",JOptionPane.YES_NO_CANCEL_OPTION);
+//
+//                    if(confirm == JOptionPane.OK_OPTION){
+//                        for (int i=0;i<jTabbedPane.getTabCount();i++){
+//                            try{
+//                                openFiles.get((i)).save();
+//                            }
+//                            catch (Exception exception)
+//                            {
+//                                exception.printStackTrace();
+//                            }
+//                        }
+//                        JOptionPane.showMessageDialog(instance,"Saved");                                                
+//                        instance=null;
+//                        setVisible(false);
+//                        dispose();
+//                    }
+//                    else if(confirm == JOptionPane.NO_OPTION){
+//                    	instance=null;
+//                        setVisible(false);
+//                        dispose();                        
+//                    }                 
+                                        
                 }
-                super.windowClosing(e);
-                instance=null;
+                
             }
         });
     }

--- a/jswingripples/src/main/java/org/incha/ui/texteditor/TextEditor.java
+++ b/jswingripples/src/main/java/org/incha/ui/texteditor/TextEditor.java
@@ -156,35 +156,18 @@ public class TextEditor extends JFrame {
                             exception.printStackTrace();
                         }
                     }                                                                    
-                    instance=null;
-                    setVisible(false);
-                    dispose();
-                	
-//                    int confirm = JOptionPane.showConfirmDialog(instance,"Would you like to save the changes?","Confirm",JOptionPane.YES_NO_CANCEL_OPTION);
-//
-//                    if(confirm == JOptionPane.OK_OPTION){
-//                        for (int i=0;i<jTabbedPane.getTabCount();i++){
-//                            try{
-//                                openFiles.get((i)).save();
-//                            }
-//                            catch (Exception exception)
-//                            {
-//                                exception.printStackTrace();
-//                            }
-//                        }
-//                        JOptionPane.showMessageDialog(instance,"Saved");                                                
-//                        instance=null;
-//                        setVisible(false);
-//                        dispose();
-//                    }
-//                    else if(confirm == JOptionPane.NO_OPTION){
-//                    	instance=null;
-//                        setVisible(false);
-//                        dispose();                        
-//                    }                 
-                                        
+                    disposeFrame();  
+                }
+                else { //No tabs open
+                	disposeFrame();
                 }
                 
+            }
+            
+            private void disposeFrame(){
+            	instance=null;
+                setVisible(false);
+                dispose(); 
             }
         });
     }


### PR DESCRIPTION
Issues solved:

https://github.com/JSwingRipples2016/jswingripples/issues/29
https://github.com/JSwingRipples2016/jswingripples/issues/12

The following describes the actual behavior of TextEditor when closing:
- Close every tab calling the close method for the tab
- If a tab was changed displays a confirm dialog with the options "Si", "No", "Cancelar". This options should be in english, and "Cancelar" (Cancel) actually doesn't work (Has the same effect of "No").
- If a tab wasn't changed, doesn't ask anything and close the tab. 

