### PR TITLE
The proper project is selected when start analysis dialog is launched…

### DIFF
--- a/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
+++ b/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
@@ -78,7 +78,7 @@ public class JSwingRipplesApplication extends JFrame {
         if (path[path.length -1] instanceof JavaProject) {
             final JavaProject project = (JavaProject) path[path.length -1];
             final JPopupMenu menu = new JPopupMenu();
-
+            
             //delete project menu item
             final JMenuItem delete = new JMenuItem("Delete Project");
             delete.addActionListener(new ActionListener() {
@@ -101,7 +101,7 @@ public class JSwingRipplesApplication extends JFrame {
 
             //start analysis
             final JMenuItem startAnalysis = new JMenuItem("Start analysis");
-            startAnalysis.addActionListener(new StartAnalysisAction());
+            startAnalysis.addActionListener(new StartAnalysisAction(project.getName()));
             menu.add(startAnalysis);
 
             menu.show(projectsView, e.getX(), e.getY());

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
@@ -17,12 +17,24 @@ import org.incha.ui.JSwingRipplesApplication;
 import org.incha.ui.jripples.JRipplesDefaultModulesConstants;
 
 public class StartAnalysisAction implements ActionListener {
+	private String projectSelected;
+	
     /**
      * Default constructor.
      */
 	
     public StartAnalysisAction() {
         super();
+        setProjectSelected(null);
+    }
+    
+    /**
+     * Constructor made to launch start analysis dialog with project withProject selected
+     * @param withProject
+     */
+    public StartAnalysisAction(String withProject){
+    	super();
+    	setProjectSelected(withProject);    	
     }
 
     /* (non-Javadoc)
@@ -110,8 +122,24 @@ public class StartAnalysisAction implements ActionListener {
             e1.printStackTrace();
         }
     }
+    
+    /**
+     * projectSelected getter
+     * @return projectSelected
+     */
+    protected String getProjectSelected() {
+		return projectSelected;
+	}
 
-    private class GraphBuild implements Runnable
+    /**
+     * projectSelected setter
+     * @param projectSelected
+     */
+	protected void setProjectSelected(String projectSelected) {
+		this.projectSelected = projectSelected;
+	}
+
+	private class GraphBuild implements Runnable
     {
         @Override
         public void run() {

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
@@ -103,6 +103,10 @@ public class StartAnalysisDialog extends JDialog {
         south.add(cancel);
         getContentPane().add(south, BorderLayout.SOUTH);
 
+        // select proper project
+        if (startAnalysisCallback.getProjectSelected() != null){        	
+        	projects.setSelectedItem(startAnalysisCallback.getProjectSelected());        	
+        }
         //set up default values
         projectChanged();
     }


### PR DESCRIPTION
… from Projects View

Added a new constructor at StartAnalysisAction.java to capture the selected project in Projects View.

Fixed issue #23

![2016-10-27](https://cloud.githubusercontent.com/assets/16597309/19754576/16bb61ea-9be5-11e6-9afd-96aec4148322.png)
![2016-10-27 1](https://cloud.githubusercontent.com/assets/16597309/19754575/16b9d29e-9be5-11e6-9d28-9afa1be8e04e.png)