### PR TITLE
Small fix in JRipplesModuleRunner

### DIFF
--- a/jswingripples/src/main/java/org/incha/core/jswingripples/JRipplesModuleRunner.java
+++ b/jswingripples/src/main/java/org/incha/core/jswingripples/JRipplesModuleRunner.java
@@ -19,7 +19,7 @@ public class JRipplesModuleRunner {
         this.listener = listener;
     }
 
-    public void moduleFinished() {
+    public synchronized void moduleFinished() {
         // this method is called by each running module
         if (++modulesFinished == targetModulesRunning) {
             // a module runner run is successful only if all


### PR DESCRIPTION
Since moduleFinished() is called by multiple threads, it must be synchronized to avoid dataraces.