### PR TITLE
Fix search action!

### DIFF
--- a/jswingripples/src/main/java/org/incha/core/jswingripples/GraphBuilder.java
+++ b/jswingripples/src/main/java/org/incha/core/jswingripples/GraphBuilder.java
@@ -136,40 +136,24 @@ public class GraphBuilder implements JSwingRipplesEIGListener{
             return;
         size = 40;
         text_size = 15;
-        //resetGraphs();
         JSwingRipplesEIGNode[] eigNodes = eig.getAllNodes();
         JSwingRipplesEIGEdge[] eigEdges = eig.getAllEdges();
 
-        //final TaskProgressMonitor monitor = JSwingRipplesApplication.getInstance().getProgressMonitor();
-        //monitor.beginTask("Building graph: Adding nodes.", eigNodes.length);
         for ( int i = 0; i < eigNodes.length; i++ ) {
             JSwingRipplesEIGNode node = eigNodes[i];
-            //monitor.worked(i);
-            //monitor.setTaskName("Adding node " + node.getShortName());
             if (graph.getNode(node.getFullName()) == null) {
                     Node n = graph.addNode(node.getFullName());
                     n.addAttribute("label", node.getShortName());
             }
         }
-        //monitor.done();
-
-        //monitor.beginTask("Building graph: Adding edges.", eigEdges.length);
         for ( int i = 0; i < eigEdges.length; i++ )
         {
             JSwingRipplesEIGEdge edge = eigEdges[i];
-            //monitor.worked(i);
             String eid = edge.getFromNode().getFullName() + " -> " + edge.getToNode().getFullName();
-            //monitor.setTaskName("Adding edge " + eid);
             if ( graph.getEdge(eid) == null){
                 graph.addEdge(eid, edge.getFromNode().getFullName(), edge.getToNode().getFullName(), true);
             }
         }
-        
-       
-
-        
-        
-        //monitor.done();
     }
 
     public Graph getDependencyGraph() { return graph; }

--- a/jswingripples/src/main/java/org/incha/core/jswingripples/GraphBuilder.java
+++ b/jswingripples/src/main/java/org/incha/core/jswingripples/GraphBuilder.java
@@ -2,6 +2,7 @@ package org.incha.core.jswingripples;
 
 import org.apache.commons.logging.LogFactory;
 import org.graphstream.graph.Graph;
+import org.graphstream.graph.IdAlreadyInUseException;
 import org.graphstream.graph.Node;
 import org.graphstream.graph.implementations.DefaultGraph;
 import org.graphstream.graph.implementations.MultiGraph;
@@ -139,26 +140,26 @@ public class GraphBuilder implements JSwingRipplesEIGListener{
         JSwingRipplesEIGNode[] eigNodes = eig.getAllNodes();
         JSwingRipplesEIGEdge[] eigEdges = eig.getAllEdges();
 
-        final TaskProgressMonitor monitor = JSwingRipplesApplication.getInstance().getProgressMonitor();
-        monitor.beginTask("Building graph: Adding nodes.", eigNodes.length);
+        //final TaskProgressMonitor monitor = JSwingRipplesApplication.getInstance().getProgressMonitor();
+        //monitor.beginTask("Building graph: Adding nodes.", eigNodes.length);
         for ( int i = 0; i < eigNodes.length; i++ ) {
             JSwingRipplesEIGNode node = eigNodes[i];
-            monitor.worked(i);
-            monitor.setTaskName("Adding node " + node.getShortName());
+            //monitor.worked(i);
+            //monitor.setTaskName("Adding node " + node.getShortName());
             if (graph.getNode(node.getFullName()) == null) {
-                Node n = graph.addNode(node.getFullName());
-                n.addAttribute("label", node.getShortName());
+                    Node n = graph.addNode(node.getFullName());
+                    n.addAttribute("label", node.getShortName());
             }
         }
-        monitor.done();
+        //monitor.done();
 
-        monitor.beginTask("Building graph: Adding edges.", eigEdges.length);
+        //monitor.beginTask("Building graph: Adding edges.", eigEdges.length);
         for ( int i = 0; i < eigEdges.length; i++ )
         {
             JSwingRipplesEIGEdge edge = eigEdges[i];
-            monitor.worked(i);
+            //monitor.worked(i);
             String eid = edge.getFromNode().getFullName() + " -> " + edge.getToNode().getFullName();
-            monitor.setTaskName("Adding edge " + eid);
+            //monitor.setTaskName("Adding edge " + eid);
             if ( graph.getEdge(eid) == null){
                 graph.addEdge(eid, edge.getFromNode().getFullName(), edge.getToNode().getFullName(), true);
             }
@@ -168,7 +169,7 @@ public class GraphBuilder implements JSwingRipplesEIGListener{
 
         
         
-        monitor.done();
+        //monitor.done();
     }
 
     public Graph getDependencyGraph() { return graph; }

--- a/jswingripples/src/main/java/org/incha/core/search/Indexer.java
+++ b/jswingripples/src/main/java/org/incha/core/search/Indexer.java
@@ -46,7 +46,7 @@ public class Indexer {
         }
         return instance;
     }
-    
+
     /**
      * Creates an index of all files in the project.
      * @param eig the eig of the java project being indexed.
@@ -135,6 +135,4 @@ public class Indexer {
             writer.addDocument(document);
         }
     }
-
-
 }

--- a/jswingripples/src/main/java/org/incha/core/search/Indexer.java
+++ b/jswingripples/src/main/java/org/incha/core/search/Indexer.java
@@ -53,6 +53,7 @@ public class Indexer {
      * @throws IOException
      */
     private IndexWriter openWriter() throws IOException {
+        deleteOldIndex();
         // Directory that will contain indexes
         Directory indexDirectory = FSDirectory.open(new File(LuceneConstants.INDEX_DIRECTORY_PATH));
 
@@ -61,6 +62,16 @@ public class Indexer {
         IndexWriterConfig indexWriterConfig = new IndexWriterConfig(Version.LUCENE_36, analyzer);
         indexWriterConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
         return new IndexWriter(indexDirectory, indexWriterConfig);
+    }
+
+    private void deleteOldIndex() {
+        File searchIndexesDirectory = new File(LuceneConstants.INDEX_DIRECTORY_PATH);
+        if(searchIndexesDirectory.exists() && searchIndexesDirectory.isDirectory()){
+            for (File f: searchIndexesDirectory.listFiles()){
+                f.delete();
+            }
+            searchIndexesDirectory.delete();
+        }
     }
 
     /**

--- a/jswingripples/src/main/java/org/incha/core/search/Indexer.java
+++ b/jswingripples/src/main/java/org/incha/core/search/Indexer.java
@@ -58,7 +58,7 @@ public class Indexer {
             File file = new File(node.getNodeIMember().getCompilationUnit().getPath().toString());
             if (validFileFilter.accept(file)) indexFile(file, writer);
         }
-        closeWriter(writer);
+        writer.close();
     }
 
     /**
@@ -86,14 +86,6 @@ public class Indexer {
             }
             searchIndexesDirectory.delete();
         }
-    }
-
-    /**
-     * Close the received writer.
-     * @throws IOException
-     */
-    private void closeWriter(IndexWriter writer) throws IOException {
-        writer.close();
     }
 
     /**

--- a/jswingripples/src/main/java/org/incha/core/search/Indexer.java
+++ b/jswingripples/src/main/java/org/incha/core/search/Indexer.java
@@ -46,6 +46,20 @@ public class Indexer {
         }
         return instance;
     }
+    
+    /**
+     * Creates an index of all files in the project.
+     * @param eig the eig of the java project being indexed.
+     * @throws IOException
+     */
+    public void indexEIG(JSwingRipplesEIG eig) throws IOException {
+        IndexWriter writer = openWriter();
+        for (JSwingRipplesEIGNode node : eig.getAllNodes()) {
+            File file = new File(node.getNodeIMember().getCompilationUnit().getPath().toString());
+            if (validFileFilter.accept(file)) indexFile(file, writer);
+        }
+        closeWriter(writer);
+    }
 
     /**
      * Creates a new IndexWriter object for creating and maintaining indexes.
@@ -122,17 +136,5 @@ public class Indexer {
         }
     }
 
-    /**
-     * Creates an index of all files in the project.
-     * @param eig the eig of the java project being indexed.
-     * @throws IOException
-     */
-    public void indexEIG(JSwingRipplesEIG eig) throws IOException {
-        IndexWriter writer = openWriter();
-        for (JSwingRipplesEIGNode node : eig.getAllNodes()) {
-            File file = new File(node.getNodeIMember().getCompilationUnit().getPath().toString());
-            if (validFileFilter.accept(file)) indexFile(file, writer);
-        }
-        closeWriter(writer);
-    }
+
 }

--- a/jswingripples/src/main/java/org/incha/core/search/LuceneConstants.java
+++ b/jswingripples/src/main/java/org/incha/core/search/LuceneConstants.java
@@ -5,9 +5,9 @@ package org.incha.core.search;
  * Class containing constants for the Indexer and Searcher classes.
  */
 public class LuceneConstants {
-    static final String CONTENTS = "contents";
-    static final String FILE_NAME = "filename";
-    static final String FILE_PATH = "filepath";
+    public static final String CONTENTS = "contents";
+    public static final String FILE_NAME = "filename";
+    public static final String FILE_PATH = "filepath";
     public static final String INDEX_DIRECTORY_PATH = System.getProperty("user.dir") + "/.SearchIndexes";
-    static final int MAX_RESULTS_ITEMS = 10000;
+    public static final int MAX_RESULTS_ITEMS = 10000;
 }

--- a/jswingripples/src/main/java/org/incha/core/search/LuceneConstants.java
+++ b/jswingripples/src/main/java/org/incha/core/search/LuceneConstants.java
@@ -4,10 +4,10 @@ package org.incha.core.search;
  * Created by fcocl_000 on 07-05-2016.
  * Class containing constants for the Indexer and Searcher classes.
  */
-class LuceneConstants {
+public class LuceneConstants {
     static final String CONTENTS = "contents";
     static final String FILE_NAME = "filename";
     static final String FILE_PATH = "filepath";
-    static final String INDEX_DIRECTORY_PATH = System.getProperty("user.dir") + "/.SearchIndexes";
+    public static final String INDEX_DIRECTORY_PATH = System.getProperty("user.dir") + "/.SearchIndexes";
     static final int MAX_RESULTS_ITEMS = 10000;
 }

--- a/jswingripples/src/main/java/org/incha/core/search/Searcher.java
+++ b/jswingripples/src/main/java/org/incha/core/search/Searcher.java
@@ -242,21 +242,12 @@ public class Searcher {
     public Map<String, Integer> getResults() {
     	return results;
     }
-
-    public List<String> getResultsList() { return resultsList; }
     
     /**
      * Return a list of the lines where the words were found
      */
     public List<Object []> getResInfo() {
     	return res_information;
-    }
-    
-    /**
-     * Deletes the elements of the list res_information
-     */
-    public void clearResInfo() {
-    	res_information.clear();
     }
     
     /**

--- a/jswingripples/src/main/java/org/incha/ui/search/StartSearchWorker.java
+++ b/jswingripples/src/main/java/org/incha/ui/search/StartSearchWorker.java
@@ -3,6 +3,7 @@ package org.incha.ui.search;
 import org.apache.lucene.queryParser.ParseException;
 import org.graphstream.ui.view.Viewer;
 import org.incha.core.jswingripples.NodeSearchBuilder;
+import org.incha.core.jswingripples.eig.JSwingRipplesEIG;
 import org.incha.core.search.Searcher;
 import org.incha.ui.JSwingRipplesApplication;
 import org.incha.ui.TaskProgressMonitor;
@@ -61,8 +62,8 @@ class StartSearchWorker extends SwingWorker<Void, String> {
 
     @Override
     protected void done() {
-        final TaskProgressMonitor monitor= JSwingRipplesApplication.getInstance().getProgressMonitor();
-        monitor.setTaskName("Search finished");
+        JSwingRipplesApplication.getInstance().getProgressMonitor().setTaskName("Search finished");
+        JSwingRipplesApplication.getInstance().repaint();
     }
 
     @Override

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
@@ -2,8 +2,10 @@ package org.incha.ui.stats;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.File;
 import java.io.IOException;
 
+import org.apache.lucene.store.FSDirectory;
 import org.incha.core.JavaProject;
 import org.incha.core.JavaProjectsModel;
 import org.incha.core.ModuleConfiguration;
@@ -13,6 +15,7 @@ import org.incha.core.jswingripples.JRipplesModuleRunner;
 import org.incha.core.jswingripples.NodeSearchBuilder;
 import org.incha.core.jswingripples.eig.JSwingRipplesEIG;
 import org.incha.core.search.Indexer;
+import org.incha.core.search.LuceneConstants;
 import org.incha.ui.JSwingRipplesApplication;
 import org.incha.ui.jripples.JRipplesDefaultModulesConstants;
 
@@ -54,12 +57,17 @@ public class StartAnalysisAction implements ActionListener {
         if (projectName == null) {
             return;
         }
-
+        File searchIndexesDirectory = new File(LuceneConstants.INDEX_DIRECTORY_PATH);
+        if(searchIndexesDirectory.exists() && searchIndexesDirectory.isDirectory()){
+            for (File f: searchIndexesDirectory.listFiles()){
+                f.delete();
+            }
+            searchIndexesDirectory.delete();
+        }
         final JavaProject project = JavaProjectsModel.getInstance().getProject(projectName);
         final JSwingRipplesEIG eig = new JSwingRipplesEIG(project);
 
         eig.setMainClass(dialog.getMainClass());
-
         final ModuleConfiguration config = new ModuleConfiguration();
         //module dependency builder
         String module = (String) dialog.dependencyGraph.getSelectedItem();

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
@@ -96,16 +96,6 @@ public class StartAnalysisAction implements ActionListener {
         new JRipplesModuleRunner(new JRipplesModuleRunner.ModuleRunnerListener() {
             @Override
             public void runSuccessful() {
-                GraphBuilder.getInstance().addEIG(eig);
-                GraphBuilder.getInstance().resetGraphs();
-                GraphBuilder.getInstance().prepareGraphs();
-                eig.addJRipplesEIGListener(GraphBuilder.getInstance());
-                try {
-                    NodeSearchBuilder.getInstance().addEIG(eig);
-                } catch (CloneNotSupportedException e2) {
-                    e2.printStackTrace();
-                }
-                // Set search indexer current project.
                 try {
                     Indexer.getInstance().indexEIG(eig);
                 } catch (IOException e1) {

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
@@ -103,7 +103,6 @@ public class StartAnalysisAction implements ActionListener {
                 try {
                     NodeSearchBuilder.getInstance().addEIG(eig);
                 } catch (CloneNotSupportedException e2) {
-                    // TODO Auto-generated catch block
                     e2.printStackTrace();
                 }
                 // Set search indexer current project.

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
@@ -95,6 +95,22 @@ public class StartAnalysisAction implements ActionListener {
         new JRipplesModuleRunner(new JRipplesModuleRunner.ModuleRunnerListener() {
             @Override
             public void runSuccessful() {
+                GraphBuilder.getInstance().addEIG(eig);
+                GraphBuilder.getInstance().resetGraphs();
+                GraphBuilder.getInstance().prepareGraphs();
+                eig.addJRipplesEIGListener(GraphBuilder.getInstance());
+                try {
+                    NodeSearchBuilder.getInstance().addEIG(eig);
+                } catch (CloneNotSupportedException e2) {
+                    // TODO Auto-generated catch block
+                    e2.printStackTrace();
+                }
+                // Set search indexer current project.
+                try {
+                    Indexer.getInstance().indexEIG(eig);
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
                 StatisticsManager.getInstance().addStatistics(config, eig);
             }
 
@@ -104,23 +120,7 @@ public class StartAnalysisAction implements ActionListener {
             }
         }).runModules(config.buildModules(eig));
 
-        GraphBuilder.getInstance().addEIG(eig);
-        GraphBuilder.getInstance().resetGraphs();
-        Thread t = new Thread(new GraphBuild());
-        t.start();
-        eig.addJRipplesEIGListener(GraphBuilder.getInstance());
-        try {
-            NodeSearchBuilder.getInstance().addEIG(eig);
-        } catch (CloneNotSupportedException e2) {
-            // TODO Auto-generated catch block
-            e2.printStackTrace();
-        }
-        // Set search indexer current project.
-        try {
-            Indexer.getInstance().indexEIG(eig);
-        } catch (IOException e1) {
-            e1.printStackTrace();
-        }
+
     }
     
     /**

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
@@ -57,13 +57,6 @@ public class StartAnalysisAction implements ActionListener {
         if (projectName == null) {
             return;
         }
-        File searchIndexesDirectory = new File(LuceneConstants.INDEX_DIRECTORY_PATH);
-        if(searchIndexesDirectory.exists() && searchIndexesDirectory.isDirectory()){
-            for (File f: searchIndexesDirectory.listFiles()){
-                f.delete();
-            }
-            searchIndexesDirectory.delete();
-        }
         final JavaProject project = JavaProjectsModel.getInstance().getProject(projectName);
         final JSwingRipplesEIG eig = new JSwingRipplesEIG(project);
 

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisAction.java
@@ -139,12 +139,4 @@ public class StartAnalysisAction implements ActionListener {
 	protected void setProjectSelected(String projectSelected) {
 		this.projectSelected = projectSelected;
 	}
-
-	private class GraphBuild implements Runnable
-    {
-        @Override
-        public void run() {
-            GraphBuilder.getInstance().prepareGraphs();
-        }
-    }
 }


### PR DESCRIPTION
- All Lucene constants are now public, instead of default

- Before the classes index is created, any potential previously generated index is deleted. This was the reason of runtime exception.

- Main GUI is repainted after a search action. Swing needs this to know when to update the view (which is usually done after each click, or when some custom event like this triggers it). 