### PR TITLE
RS035 go and clear button disabled after close all tabs

### DIFF
--- a/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
+++ b/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
@@ -23,6 +23,8 @@ import java.util.Properties;
 public class JSwingRipplesApplication extends JFrame {
     private static final long serialVersionUID = 6142679404175274529L;
     private JTabbedPane viewArea;
+    private int tabbedAreaCount = 0;
+    private SearchMenu searchMenu;
     private final ProjectsView projectsView;
     private static JSwingRipplesApplication instance;
     private TaskProgressMonitor progressMonitor;
@@ -31,14 +33,11 @@ public class JSwingRipplesApplication extends JFrame {
         super("JSwingRipples");
         this.viewArea = viewArea;
         this.progressMonitor = progressMonitor;
-
         addJTabbedPaneMouseListener(viewArea);
-
         setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         final JPanel contentPane = new JPanel(new BorderLayout(0, 5));
         setContentPane(contentPane);
         contentPane.setBorder(new EmptyBorder(2, 2, 2, 2));
-
         setJMenuBar(createMenuBar());
 
         projectsView = new ProjectsView(JavaProjectsModel.getInstance());
@@ -319,7 +318,7 @@ public class JSwingRipplesApplication extends JFrame {
         /* End: Help Menu */
         
         /* Start: Search Menu */
-        SearchMenu searchMenu = new SearchMenu();
+        searchMenu = new SearchMenu();
         Searcher.getInstance().setSearchMenu(searchMenu);
         bar.add(searchMenu.getSearchPanel());
         /* End: Search Menu */
@@ -426,6 +425,7 @@ public class JSwingRipplesApplication extends JFrame {
     }
 
     public void addComponentAsTab(JComponent component, String tabTitle) {
+        this.tabbedAreaCount += 1;
         viewArea.addTab(tabTitle, component);
     }
 
@@ -441,6 +441,12 @@ public class JSwingRipplesApplication extends JFrame {
                         @Override
                         public void actionPerformed(final ActionEvent e) {
                             viewArea.removeTabAt(viewArea.getSelectedIndex());
+                            tabbedAreaCount -= 1;
+                            if(tabbedAreaCount == 0){
+                                JMenuBar mb = getJMenuBar();
+                                searchMenu.getClearButton().setEnabled(false);
+                                searchMenu.getSearchButton().setEnabled(false);
+                            }
                         }
                     });
                     menu.add(close);

--- a/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
+++ b/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
@@ -425,7 +425,7 @@ public class JSwingRipplesApplication extends JFrame {
     }
 
     public void addComponentAsTab(JComponent component, String tabTitle) {
-        this.tabbedAreaCount += 1;
+        this.tabbedAreaCount++;
         viewArea.addTab(tabTitle, component);
     }
 
@@ -441,7 +441,7 @@ public class JSwingRipplesApplication extends JFrame {
                         @Override
                         public void actionPerformed(final ActionEvent e) {
                             viewArea.removeTabAt(viewArea.getSelectedIndex());
-                            tabbedAreaCount -= 1;
+                            tabbedAreaCount--;
                             if(tabbedAreaCount == 0){
                                 JMenuBar mb = getJMenuBar();
                                 searchMenu.getClearButton().setEnabled(false);


### PR DESCRIPTION
Clear and Go buttons now are disabled after all tabs in the view area are closed (issue #57)
![rs035fix](https://cloud.githubusercontent.com/assets/8240682/20467285/6993f8c8-af63-11e6-9b90-796495a873b8.gif)
