### PR TITLE
Fixed spammable analysis button

### DIFF
--- a/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
+++ b/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
@@ -235,6 +235,10 @@ public class JSwingRipplesApplication extends JFrame {
         }
     }
 
+    public void enableProceedButton(boolean enable){
+        proceedButton.setEnabled(enable);
+    }
+
     public void refreshViewArea() {
         viewArea.repaint();
     }

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
@@ -155,6 +155,7 @@ public class StartAnalysisDialog extends JDialog {
 
     protected void doOk() {
         dispose();
+        JSwingRipplesApplication.getInstance().enableProceedButton(true);
         startAnalysisCallback.startAnalysis(
                 createConceptLocationData(), new StartAnalysisAction.SuccessfulAnalysisAction() {
             @Override
@@ -164,6 +165,7 @@ public class StartAnalysisDialog extends JDialog {
                 JSwingRipplesApplication.getInstance().setProceedButtonListener(new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
+                        JSwingRipplesApplication.getInstance().enableProceedButton(false);
                         startAnalysisCallback.startAnalysis(createImpactAnalysisData(eig), createImpactAnalysisCallback());
                     }
                 });
@@ -278,6 +280,7 @@ public class StartAnalysisDialog extends JDialog {
         return new StartAnalysisAction.SuccessfulAnalysisAction() {
             @Override
             public void execute(ModuleConfiguration config, JSwingRipplesEIG eig) {
+                JSwingRipplesApplication.getInstance().enableProceedButton(true);
                 JSwingRipplesApplication.getInstance().hideProceedButton();
                 JSwingRipplesApplication.getInstance().resetProceedButton();
                 JSwingRipplesApplication.getInstance().refreshViewArea();
@@ -289,11 +292,13 @@ public class StartAnalysisDialog extends JDialog {
         return new StartAnalysisAction.SuccessfulAnalysisAction() {
             @Override
             public void execute(ModuleConfiguration config,final JSwingRipplesEIG eig) {
+                JSwingRipplesApplication.getInstance().enableProceedButton(true);
                 JSwingRipplesApplication.getInstance().refreshViewArea();
                 JSwingRipplesApplication.getInstance().setProceedButtonText("Proceed To Change Propagation");
                 JSwingRipplesApplication.getInstance().setProceedButtonListener(new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
+                        JSwingRipplesApplication.getInstance().enableProceedButton(false);
                         startAnalysisCallback.startAnalysis(
                                 createChangePropagationData(eig), createChangePropagationCallback());
                     }


### PR DESCRIPTION
Proceed to [Next Phase here] Button was not being disabled while the analysis was being executed, resulting in the possibility of spamming the button and crashing the app. The button is now disabled every time it's clicked. No Issue was reported for this yet.


![jswingripples button spam](https://cloud.githubusercontent.com/assets/9152806/21188799/4f0b9a88-c1fb-11e6-8a6c-97705bbc0456.png)
