### PR TITLE
Browse and Auto buttons is disabled when no project is loaded

### DIFF
--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
@@ -213,6 +213,7 @@ public class StartAnalysisDialog extends JDialog {
 
     private JButton createAutomaticButton() {
         JButton automaticButton = new JButton("Auto");
+        automaticButton.setEnabled(projects.getItemCount()!=0);
         automaticButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(final ActionEvent e) {
@@ -233,6 +234,7 @@ public class StartAnalysisDialog extends JDialog {
 
     private JButton createBrowseButton() {
         JButton browseButton = new JButton("Browse");
+        browseButton.setEnabled(projects.getItemCount()!=0);
         browseButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(final ActionEvent e) {


### PR DESCRIPTION
Disabling the buttons browse and auto to select the main class when no project is loaded