### PR TITLE
Unique analysis fix

### DIFF
--- a/jswingripples/src/main/java/org/incha/ui/DefaultController.java
+++ b/jswingripples/src/main/java/org/incha/ui/DefaultController.java
@@ -74,6 +74,9 @@ public class DefaultController implements StatisticsChangeListener {
 
         final JScrollPane comp = new JScrollPane(view);
         comp.getViewport().setBackground(Color.WHITE);
+        if(JSwingRipplesApplication.getInstance().isAnotherProjectOpen()){
+            JSwingRipplesApplication.getInstance().removeAllTabs();
+        }
         JSwingRipplesApplication.getInstance().addComponentAsTab(comp, "Project: " + project.getName());
     }
 

--- a/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
+++ b/jswingripples/src/main/java/org/incha/ui/JSwingRipplesApplication.java
@@ -202,6 +202,12 @@ public class JSwingRipplesApplication extends JFrame {
         viewArea.addTab(tabTitle, component);
     }
 
+    public void removeAllTabs(){
+        for(int i = 0 ; i < viewArea.getTabCount(); i++){
+            viewArea.removeTabAt(i);
+        }
+    }
+
     public void enableSearchMenuButtons() {
         mainMenuBar.getSearchMenu().getSearchButton().setEnabled(true);
         mainMenuBar.getSearchMenu().getClearButton().setEnabled(true);
@@ -241,6 +247,10 @@ public class JSwingRipplesApplication extends JFrame {
 
     public void refreshViewArea() {
         viewArea.repaint();
+    }
+
+    public boolean isAnotherProjectOpen(){
+        return viewArea.getTabCount() > 0;
     }
 
     private void addJTabbedPaneMouseListener(JTabbedPane pane){

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
@@ -156,6 +156,7 @@ public class StartAnalysisDialog extends JDialog {
     protected void doOk() {
         dispose();
         JSwingRipplesApplication.getInstance().enableProceedButton(true);
+        JSwingRipplesApplication.getInstance().setProceedButtonText("Proceed to Impact Analysis");
         startAnalysisCallback.startAnalysis(
                 createConceptLocationData(), new StartAnalysisAction.SuccessfulAnalysisAction() {
             @Override

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
@@ -157,7 +157,9 @@ public class StartAnalysisDialog extends JDialog {
         if(JSwingRipplesApplication.getInstance().isAnotherProjectOpen()){
             String[] options = new String[]{"Yes","Cancel"};
             int result = JOptionPane.showOptionDialog(this,
-                    new String[]{"There is another analysis in progress.\n Are you sure you want to begin a start a new one? All progress from the last analysis will be lost."},
+                    new String[]{"There is another analysis in progress.\n " +
+                            "Are you sure you want to begin a start a new one? " +
+                            "All progress from the last analysis will be lost."},
                     "Another analysis in progress",
                     JOptionPane.YES_NO_OPTION,
                     JOptionPane.WARNING_MESSAGE,

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
@@ -154,24 +154,48 @@ public class StartAnalysisDialog extends JDialog {
     }
 
     protected void doOk() {
+        if(JSwingRipplesApplication.getInstance().isAnotherProjectOpen()){
+            String[] options = new String[]{"Yes","Cancel"};
+            int result = JOptionPane.showOptionDialog(this,
+                    new String[]{"There is another analysis in progress.\n Are you sure you want to begin a start a new one? All progress from the last analysis will be lost."},
+                    "Another analysis in progress",
+                    JOptionPane.YES_NO_OPTION,
+                    JOptionPane.WARNING_MESSAGE,
+                    null,
+                    options,
+                    options[0]);
+            switch(result){
+                case JOptionPane.YES_OPTION:
+                    beginConceptLocation();
+                    break;
+                case JOptionPane.CANCEL_OPTION:
+                    break;
+            }
+        } else {
+            beginConceptLocation();
+        }
+
+    }
+
+    private void beginConceptLocation(){
         dispose();
         JSwingRipplesApplication.getInstance().enableProceedButton(true);
         JSwingRipplesApplication.getInstance().setProceedButtonText("Proceed to Impact Analysis");
         startAnalysisCallback.startAnalysis(
-                createConceptLocationData(), new StartAnalysisAction.SuccessfulAnalysisAction() {
-            @Override
-            public void execute(ModuleConfiguration config, final JSwingRipplesEIG eig) {
+            createConceptLocationData(), new StartAnalysisAction.SuccessfulAnalysisAction() {
+                @Override
+                public void execute(ModuleConfiguration config, final JSwingRipplesEIG eig) {
                 JSwingRipplesApplication.getInstance().showProceedButton();
                 StatisticsManager.getInstance().addStatistics(config, eig);
                 JSwingRipplesApplication.getInstance().setProceedButtonListener(new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        JSwingRipplesApplication.getInstance().enableProceedButton(false);
-                        startAnalysisCallback.startAnalysis(createImpactAnalysisData(eig), createImpactAnalysisCallback());
+                    JSwingRipplesApplication.getInstance().enableProceedButton(false);
+                    startAnalysisCallback.startAnalysis(createImpactAnalysisData(eig), createImpactAnalysisCallback());
                     }
                 });
-            }
-        });
+                }
+            });
     }
     
     protected void setClassName(final String classNameParam, String fileName){

--- a/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
+++ b/jswingripples/src/main/java/org/incha/ui/stats/StartAnalysisDialog.java
@@ -164,12 +164,8 @@ public class StartAnalysisDialog extends JDialog {
                     null,
                     options,
                     options[0]);
-            switch(result){
-                case JOptionPane.YES_OPTION:
-                    beginConceptLocation();
-                    break;
-                case JOptionPane.CANCEL_OPTION:
-                    break;
+            if(result == JOptionPane.YES_OPTION){
+                beginConceptLocation();
             }
         } else {
             beginConceptLocation();


### PR DESCRIPTION
There was a bug when multiple analysis were being executed that prevented each analysis to proceed to their respective next step. The fix to this was to prevent multiple analysis to be done at the same time, now only a single analysis can be executed and if a user wishes to begin another one before the last analysis was finished he is prompted with a warning message.

![jswingripplesunique](https://cloud.githubusercontent.com/assets/9152806/21195456/9d9407aa-c212-11e6-9411-d21ca1e5dd62.gif)
